### PR TITLE
fix(lexarg): Explicitly tell users about escapes

### DIFF
--- a/crates/libtest-lexarg/src/lib.rs
+++ b/crates/libtest-lexarg/src/lib.rs
@@ -464,6 +464,8 @@ impl TestOptsParseState {
                     .map_err(Error::msg)?;
                 self.opts.shuffle_seed = Some(seed);
             }
+            // All values are the same, whether escaped or not, so its a no-op
+            Arg::Escape => {}
             Arg::Value(filter) => {
                 let filter = filter
                     .to_str()

--- a/crates/libtest2-harness/src/harness.rs
+++ b/crates/libtest2-harness/src/harness.rs
@@ -115,6 +115,7 @@ fn parse(parser: &mut cli::Parser) -> cli::Result<libtest_lexarg::TestOpts> {
                 cli::Arg::Long(v) => {
                     format!("unrecognized `--{v}` flag")
                 }
+                cli::Arg::Escape => "handled `--`".to_owned(),
                 cli::Arg::Value(v) => {
                     format!("unrecognized `{}` value", v.to_string_lossy())
                 }


### PR DESCRIPTION
This allows regular escapes, clap's `last`, or external subcommands without having to provide a lot of specialized behavior.