### PR TITLE
fix(harness): Open door for shorter backtraces

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.65.0"  # MSRV
+msrv = "1.66.0"  # MSRV
 warn-on-all-wildcard-imports = true
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.65.0"
+    name: "Check MSRV: 1.66.0"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -57,7 +57,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.65.0  # MSRV
+        toolchain: 1.66.0  # MSRV
     - uses: Swatinem/rust-cache@v2
     - name: Default features
       run: cargo check --workspace --all-targets
@@ -107,7 +107,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.65.0  # MSRV
+        toolchain: 1.66.0  # MSRV
         components: clippy
     - uses: Swatinem/rust-cache@v2
     - name: Install SARIF tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65.0"  # MSRV
+rust-version = "1.66.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/crates/libtest2-harness/src/harness.rs
+++ b/crates/libtest2-harness/src/harness.rs
@@ -242,7 +242,7 @@ fn run(
         })?;
         let timer = std::time::Instant::now();
 
-        let outcome = case.run(&state);
+        let outcome = __rust_begin_short_backtrace(|| case.run(&state));
 
         let err = outcome.as_ref().err();
         let status = err.map(|e| e.status());
@@ -266,4 +266,13 @@ fn run(
     })?;
 
     Ok(success)
+}
+
+/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`.
+#[inline(never)]
+fn __rust_begin_short_backtrace<T, F: FnOnce() -> T>(f: F) -> T {
+    let result = f();
+
+    // prevent this frame from being tail-call optimised away
+    std::hint::black_box(result)
 }


### PR DESCRIPTION
This is copied straight from libtest.  No idea if there is any other side to this that we need.