### PR TITLE
feat(harness): Catch panics

### DIFF
--- a/crates/libtest2-mimic/tests/testsuite/main.rs
+++ b/crates/libtest2-mimic/tests/testsuite/main.rs
@@ -1,6 +1,7 @@
 mod all_passing;
 mod main_thread;
 mod mixed_bag;
+mod panic;
 mod util;
 
 pub use util::*;

--- a/crates/libtest2-mimic/tests/testsuite/main_thread.rs
+++ b/crates/libtest2-mimic/tests/testsuite/main_thread.rs
@@ -4,16 +4,12 @@ fn check_test_on_main_thread() {
         r#"
 fn main() {
     use libtest2_mimic::Trial;
-    use libtest2_mimic::RunError;
     let outer_thread = std::thread::current().id();
     libtest2_mimic::Harness::with_env()
         .cases(vec![
             Trial::test("check", move |_| {
-                if outer_thread == std::thread::current().id() {
-                    Ok(())
-                } else {
-                    Err(RunError::fail("thread IDs mismatch"))
-                }
+                assert_eq!(outer_thread, std::thread::current().id());
+                Ok(())
             })
         ])
         .main();

--- a/crates/libtest2-mimic/tests/testsuite/panic.rs
+++ b/crates/libtest2-mimic/tests/testsuite/panic.rs
@@ -1,0 +1,77 @@
+fn test_cmd() -> snapbox::cmd::Command {
+    static BIN: once_cell::sync::Lazy<(std::path::PathBuf, std::path::PathBuf)> =
+        once_cell::sync::Lazy::new(|| {
+            let package_root = crate::util::new_test(
+                r#"
+fn main() {
+    use libtest2_mimic::Trial;
+    libtest2_mimic::Harness::with_env()
+        .cases(vec![
+            Trial::test("passes", |_| Ok(())),
+            Trial::test("panics", |_| panic!("uh oh")),
+        ])
+        .main();
+}
+"#,
+                false,
+            );
+            let bin = crate::util::compile_test(&package_root);
+            (bin, package_root)
+        });
+    snapbox::cmd::Command::new(&BIN.0).current_dir(&BIN.1)
+}
+
+fn check(args: &[&str], code: i32, single: &str, parallel: &str) {
+    test_cmd()
+        .args(args)
+        .args(["--test-threads", "1"])
+        .assert()
+        .code(code)
+        .stdout_matches(single);
+    test_cmd()
+        .args(args)
+        .assert()
+        .code(code)
+        .stdout_matches(parallel);
+}
+
+#[test]
+fn normal() {
+    check(
+        &[],
+        101,
+        r#"
+running 2 tests
+test panics ... FAILED
+test passes ... ok
+
+failures:
+
+---- panics ----
+test panicked: uh oh
+
+
+failures:
+    panics
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 filtered out; finished in [..]s
+
+"#,
+        r#"
+running 2 tests
+...
+
+failures:
+
+---- panics ----
+test panicked: uh oh
+
+
+failures:
+    panics
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 filtered out; finished in [..]s
+
+"#,
+    );
+}


### PR DESCRIPTION
This only gives us libtest-mimic's level of quality.  There are still gaps with libtest's behavior
- We don't offer to show call stacks
- we don't install a hook to handle a uncatchable panic happening during tests

Fixes #7