### PR TITLE
clippy fix

### DIFF
--- a/crates/lexarg/src/lib.rs
+++ b/crates/lexarg/src/lib.rs
@@ -119,6 +119,7 @@ impl<'a> Parser<'a> {
     ///
     /// Options that are not valid unicode are transformed with replacement
     /// characters as by [`String::from_utf8_lossy`].
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<Arg<'a>> {
         // Always reset
         self.was_attached = false;
@@ -784,7 +785,7 @@ mod tests {
     }
 
     /// Run many sequences of methods on a Parser.
-    fn exhaust(parser: Parser<'_>, path: Vec<String>) {
+    fn exhaust(parser: Parser<'_>, mut path: Vec<String>) {
         if path.len() > 100 {
             panic!("Stuck in loop: {:?}", path);
         }
@@ -806,7 +807,6 @@ mod tests {
                 let mut parser = parser.clone();
                 let next = parser.flag_value();
                 assert!(next.is_some(), "{next:?} via {path:?}",);
-                let mut path = path.clone();
                 path.push(format!("pending-value-{:?}", next));
                 exhaust(parser, path);
             }
@@ -839,7 +839,7 @@ mod tests {
                             matches!(parser.state, None | Some(State::Escaped)),
                             "{next:?} via {path:?}",
                         );
-                        if parser.state == None && !parser.was_attached {
+                        if parser.state.is_none() && !parser.was_attached {
                             assert_eq!(parser.current, parser.raw.len(), "{next:?} via {path:?}",);
                         }
                     }
@@ -848,7 +848,6 @@ mod tests {
                             matches!(parser.state, None | Some(State::Escaped)),
                             "{next:?} via {path:?}",
                         );
-                        let mut path = path.clone();
                         path.push(format!("value-{:?}", next));
                         exhaust(parser, path);
                     }

--- a/crates/libtest-lexarg/src/lib.rs
+++ b/crates/libtest-lexarg/src/lib.rs
@@ -175,19 +175,10 @@ impl TimeThreshold {
 
 /// Options for the test run defined by the caller (instead of CLI arguments).
 /// In case we want to add other options as well, just add them in this struct.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Options {
     pub display_output: bool,
     pub panic_abort: bool,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            display_output: false,
-            panic_abort: false,
-        }
-    }
 }
 
 pub const UNSTABLE_OPTIONS: &str = "unstable-options";
@@ -342,7 +333,7 @@ impl TestOptsParseState {
                 self.opts.logfile = Some(std::path::PathBuf::from(path));
             }
             Arg::Long("nocapture") => {
-                self.opts.nocapture;
+                // self.opts.nocapture;
             }
             Arg::Long("test-threads") => {
                 let test_threads = parser
@@ -428,15 +419,10 @@ impl TestOptsParseState {
                 self.opts.allowed_unstable.push(feature.to_owned());
             }
             Arg::Long("report-time") => {
-                self.opts
-                    .time_options
-                    .get_or_insert_with(|| Default::default());
+                self.opts.time_options.get_or_insert_with(Default::default);
             }
             Arg::Long("ensure-time") => {
-                let time = self
-                    .opts
-                    .time_options
-                    .get_or_insert_with(|| Default::default());
+                let time = self.opts.time_options.get_or_insert_with(Default::default);
                 time.error_on_excess = true;
                 if let Some(threshold) = TimeThreshold::from_env_var("RUST_TEST_TIME_UNIT")? {
                     time.unit_threshold = threshold;

--- a/crates/libtest2-harness/src/notify/summary.rs
+++ b/crates/libtest2-harness/src/notify/summary.rs
@@ -68,7 +68,7 @@ impl Summary {
             // Print summary list of failed tests
             writeln!(writer)?;
             writeln!(writer, "failures:")?;
-            for (name, _) in &self.failures {
+            for name in self.failures.keys() {
                 writeln!(writer, "    {}", name)?;
             }
         }

--- a/crates/libtest2-mimic/src/lib.rs
+++ b/crates/libtest2-mimic/src/lib.rs
@@ -31,9 +31,11 @@ pub use libtest2_harness::TestKind;
 use libtest2_harness::Case;
 use libtest2_harness::Source;
 
+type Runner = Box<dyn Fn(&State) -> Result<(), RunError> + Send + Sync>;
+
 pub struct Trial {
     name: String,
-    runner: Box<dyn Fn(&State) -> Result<(), RunError> + Send + Sync>,
+    runner: Runner,
 }
 
 impl Trial {

--- a/crates/libtest2-mimic/tests/testsuite/util.rs
+++ b/crates/libtest2-mimic/tests/testsuite/util.rs
@@ -1,4 +1,6 @@
-pub fn new_test(test: &str, harness: bool) -> std::path::PathBuf {
+use std::path::{Path, PathBuf};
+
+pub fn new_test(test: &str, harness: bool) -> PathBuf {
     static SUFFIX: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
     let suffix = SUFFIX.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let target_name = format!("t{suffix}");
@@ -40,7 +42,7 @@ harness = {harness}
     package_root
 }
 
-pub fn compile_test(package_root: &std::path::PathBuf) -> std::path::PathBuf {
+pub fn compile_test(package_root: &Path) -> PathBuf {
     let manifest_path = package_root.join("Cargo.toml");
     let target_name = package_root.file_name().unwrap().to_str().unwrap();
     let args = [
@@ -50,27 +52,27 @@ pub fn compile_test(package_root: &std::path::PathBuf) -> std::path::PathBuf {
     tests::compile_test(&manifest_path, target_name, args)
 }
 
-fn mimic_relpath(root: &std::path::Path) -> std::path::PathBuf {
+fn mimic_relpath(root: &Path) -> PathBuf {
     let current_dir = std::env::current_dir().unwrap();
-    let relpath = pathdiff::diff_paths(&current_dir, &root).unwrap();
+    let relpath = pathdiff::diff_paths(current_dir, root).unwrap();
     let normalized = relpath.as_os_str().to_str().unwrap().replace('\\', "/");
-    std::path::PathBuf::from(normalized)
+    PathBuf::from(normalized)
 }
 
-fn target_dir() -> std::path::PathBuf {
+fn target_dir() -> PathBuf {
     tempdir().join("libtest2_mimic_target")
 }
 
-fn tempdir() -> std::path::PathBuf {
+fn tempdir() -> PathBuf {
     const TEMPDIR: &str = env!("CARGO_TARGET_TMPDIR");
 
-    let tempdir = std::path::Path::new(TEMPDIR);
+    let tempdir = Path::new(TEMPDIR);
     std::fs::create_dir_all(tempdir).unwrap();
-    dunce::canonicalize(&tempdir).unwrap()
+    dunce::canonicalize(tempdir).unwrap()
 }
 
 mod tests {
-    pub fn compile_test<'a>(
+    pub fn compile_test(
         manifest_path: &std::path::Path,
         target_name: &str,
         args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,


### PR DESCRIPTION
<details>
  <summary>cargo clippy --all</summary>

```rust
pytest-rs/crates ✗ cargo clippy --all
warning: method `next` can be confused for the standard trait method `std::iter::Iterator::next`
   --> crates/lexarg/src/lib.rs:122:5
    |
122 | /     pub fn next(&mut self) -> Option<Arg<'a>> {
123 | |         // Always reset
124 | |         self.was_attached = false;
125 | |
...   |
237 | |         }
238 | |     }
    | |_____^
    |
    = help: consider implementing the trait `std::iter::Iterator` or choosing a less ambiguous method name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait
    = note: `#[warn(clippy::should_implement_trait)]` on by default

warning: `lexarg` (lib) generated 1 warning
warning: this `impl` can be derived
   --> crates/libtest-lexarg/src/lib.rs:184:1
    |
184 | / impl Default for Options {
185 | |     fn default() -> Self {
186 | |         Self {
187 | |             display_output: false,
...   |
190 | |     }
191 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
    = note: `#[warn(clippy::derivable_impls)]` on by default
    = help: remove the manual implementation...
help: ...and instead derive it
    |
179 + #[derive(Default)]
180 | pub struct Options {
    |

warning: statement with no effect
   --> crates/libtest-lexarg/src/lib.rs:345:17
    |
345 |                 self.opts.nocapture;
    |                 ^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#no_effect
    = note: `#[warn(clippy::no_effect)]` on by default

warning: redundant closure
   --> crates/libtest-lexarg/src/lib.rs:433:41
    |
433 |                     .get_or_insert_with(|| Default::default());
    |                                         ^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `Default::default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
    = note: `#[warn(clippy::redundant_closure)]` on by default

warning: redundant closure
   --> crates/libtest-lexarg/src/lib.rs:439:41
    |
439 |                     .get_or_insert_with(|| Default::default());
    |                                         ^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `Default::default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure

warning: `libtest-lexarg` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p libtest-lexarg` to apply 3 suggestions)
warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> crates/libtest2-harness/src/harness.rs:174:42
    |
174 |     let seed = shuffle::get_shuffle_seed(&opts);
    |                                          ^^^^^ help: change this to: `opts`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: redundant pattern matching, consider using `is_err()`
   --> crates/libtest2-harness/src/harness.rs:264:24
    |
264 |                 if let Err(_) = self.join_handle.join() {
    |                 -------^^^^^^-------------------------- help: try this: `if self.join_handle.join().is_err()`
    |
    = note: this will change drop order of the result, as well as all temporaries
    = note: add `#[allow(clippy::redundant_pattern_matching)]` if this is important
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching
    = note: `#[warn(clippy::redundant_pattern_matching)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> crates/libtest2-harness/src/harness.rs:372:50
    |
372 |         __rust_begin_short_backtrace(|| case.run(&state))
    |                                                  ^^^^^^ help: change this to: `state`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: you are using an explicit closure for copying elements
   --> crates/libtest2-harness/src/harness.rs:381:17
    |
381 |             .or(e.downcast_ref::<&str>().map(|s| *s));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `e.downcast_ref::<&str>().copied()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
    = note: `#[warn(clippy::map_clone)]` on by default

warning: you seem to want to iterate on a map's keys
  --> crates/libtest2-harness/src/notify/summary.rs:71:30
   |
71 |             for (name, _) in &self.failures {
   |                              ^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
   = note: `#[warn(clippy::for_kv_map)]` on by default
help: use the corresponding method
   |
71 |             for name in self.failures.keys() {
   |                 ~~~~    ~~~~~~~~~~~~~~~~~~~~

warning: `libtest2-harness` (lib) generated 5 warnings (run `cargo clippy --fix --lib -p libtest2-harness` to apply 3 suggestions)
warning: very complex type used. Consider factoring parts into `type` definitions
  --> crates/libtest2-mimic/src/lib.rs:36:13
   |
36 |     runner: Box<dyn Fn(&State) -> Result<(), RunError> + Send + Sync>,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
   = note: `#[warn(clippy::type_complexity)]` on by default
```

</details>