### PR TITLE
fix!: Fix typo in `TestContext::elapsed_s`

### DIFF
--- a/crates/libtest2-harness/src/context.rs
+++ b/crates/libtest2-harness/src/context.rs
@@ -33,7 +33,7 @@ impl TestContext {
         self.notifier().notify(event)
     }
 
-    pub fn elapased_s(&self) -> notify::Elapsed {
+    pub fn elapsed_s(&self) -> notify::Elapsed {
         notify::Elapsed(self.start.elapsed())
     }
 

--- a/crates/libtest2-harness/src/harness.rs
+++ b/crates/libtest2-harness/src/harness.rs
@@ -438,7 +438,7 @@ fn run_case(case: &dyn Case, context: &TestContext) -> std::io::Result<bool> {
     context.notifier().notify(
         notify::event::CaseStart {
             name: case.name().to_owned(),
-            elapsed_s: Some(context.elapased_s()),
+            elapsed_s: Some(context.elapsed_s()),
         }
         .into(),
     )?;
@@ -472,7 +472,7 @@ fn run_case(case: &dyn Case, context: &TestContext) -> std::io::Result<bool> {
                 name: case.name().to_owned(),
                 kind,
                 message,
-                elapsed_s: Some(context.elapased_s()),
+                elapsed_s: Some(context.elapsed_s()),
             }
             .into(),
         )?;
@@ -481,7 +481,7 @@ fn run_case(case: &dyn Case, context: &TestContext) -> std::io::Result<bool> {
     context.notifier().notify(
         notify::event::CaseComplete {
             name: case.name().to_owned(),
-            elapsed_s: Some(context.elapased_s()),
+            elapsed_s: Some(context.elapsed_s()),
         }
         .into(),
     )?;


### PR DESCRIPTION
This function seems to have been incorrectly named `elapased_s`, which is not a word ofcourse. Just thought I'd fix it. The `_s` suffix is still a bit confusing to me, but it seems to be used a lot of places in the codebase, so I assume this is intentional.