### PR TITLE
fix: Add tests for accepting `#[cfg(..)]`

### DIFF
--- a/crates/libtest2-mimic/tests/testsuite/mixed_bag.rs
+++ b/crates/libtest2-mimic/tests/testsuite/mixed_bag.rs
@@ -39,11 +39,16 @@ fn main() {
                 state.ignore()?;
                 Err(RunError::fail("got lost blindly following the flock"))
             }),
+            #[cfg(all())]
             Trial::test("horse", |state| {
                 state.ignore_for("slow")?;
                 Ok(())
             }),
             Trial::test("custom_error", |_| Err(RunError::from(std::io::Error::new(std::io::ErrorKind::Other, "I failed")))),
+            #[cfg(any())]
+            Trial::test("unicorn", |state| {
+                panic!("I don't exist");
+            }),
         ])
         .main();
 }

--- a/crates/libtest2/tests/testsuite/mixed_bag.rs
+++ b/crates/libtest2/tests/testsuite/mixed_bag.rs
@@ -60,6 +60,7 @@ fn sheep(context: &libtest2::TestContext) -> libtest2::RunResult {
 }
 
 #[libtest2::test]
+#[cfg(all())]
 #[ignore = "slow"]
 fn horse(context: &libtest2::TestContext) {
 }
@@ -69,6 +70,11 @@ fn custom_error(context: &libtest2::TestContext) -> std::io::Result<()> {
     Err(std::io::Error::new(std::io::ErrorKind::Other, "I failed"))
 }
 
+#[libtest2::test]
+#[cfg(any())]
+fn unicorn(context: &libtest2::TestContext) {
+    panic!("I don't exist");
+}
 "#,
             false,
         );


### PR DESCRIPTION
This adds some tests verifying that we accept `#[cfg(..)]` together with the `#[test]` macro.

Fixes #141